### PR TITLE
using the whole cacheMultistore instead of one with only the last hei…

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -664,10 +664,9 @@ func (app *BaseApp) createQueryContext(height int64, prove bool) (sdk.Context, e
 			)
 	}
 
-	cacheMS, err := app.cms.CacheMultiStoreWithVersion(height)
-	if err != nil {
-		return sdk.Context{}, fmt.Errorf("failed to load cache multi store for height %d: %w", height, err)
-	}
+	// Passing the whole multistore in queries instead of one with only the current height, because on
+	// contract queries we use the previous height, as that's the last height with a merkle proof
+	cacheMS := app.cms.CacheMultiStore()
 
 	// branch the commit-multistore for safety
 	ctx := sdk.NewContext(


### PR DESCRIPTION
now passes the multistore with the whole history of heights to queries. Queries now query the second-to-last version of the store, because that version has a merkle-proof available