### PR TITLE
renamed the legacy-hd-path flag to cosmos-ledger-app, to better refle…

### DIFF
--- a/client/keys/add.go
+++ b/client/keys/add.go
@@ -70,10 +70,17 @@ Example:
 	f.StringSlice(flagMultisig, nil, "List of key names stored in keyring to construct a public legacy multisig key")
 	f.Int(flagMultiSigThreshold, 1, "K out of N required signatures. For use in conjunction with --multisig")
 	f.Bool(flagNoSort, false, "Keys passed to --multisig are taken in the order they're supplied")
-	f.String(FlagPublicKey, "", "Parse a public key in JSON format and saves key info to <name> file.")
+	f.String(FlagPublicKey, "", "Parse a public key in JSON format and saves key info to <name> file")
 	f.BoolP(flagInteractive, "i", false, "Interactively prompt user for BIP39 passphrase and mnemonic")
-	f.Bool(flags.FlagUseLedger, false, "Store a local reference to a private key on a Ledger device")
-	f.Bool(flagCosmosLedgerApp, false, "If using Ledger, use the old HD path, which is compatible with Cosmos app")
+	f.Bool(flags.FlagUseLedger, false, fmt.Sprintf(
+		"Store a local reference to a private key on a Ledger device (ignores --%s and --%s)",
+		flagHDPath,
+		flagCoinType,
+	))
+	f.Bool(flagCosmosLedgerApp, false, fmt.Sprintf(
+		"If using --%s, use the old HD path, which is compatible with Cosmos app",
+		flags.FlagUseLedger,
+	))
 	f.Bool(flagRecover, false, "Provide seed phrase to recover existing key instead of creating")
 	f.Bool(flagNoBackup, false, "Don't print out seed phrase (if others are watching the terminal)")
 	f.Bool(flags.FlagDryRun, false, "Perform action, but don't add key to local keystore")
@@ -210,7 +217,7 @@ func runAddCmd(ctx client.Context, cmd *cobra.Command, args []string, inBuf *buf
 	if useLedger {
 		isCosmosLedgerApp, _ := cmd.Flags().GetBool(flagCosmosLedgerApp)
 		if isCosmosLedgerApp {
-			coinType = sdk.CoinType // secret's hd path used on the old cosmos app is the same one as cosmos'
+			coinType = sdk.CoinType // the HD path used on the old cosmos app is the same one as cosmos'
 		} else {
 			coinType = DefaultLedgerCoinType
 		}

--- a/client/keys/add.go
+++ b/client/keys/add.go
@@ -21,16 +21,16 @@ import (
 )
 
 const (
-	flagInteractive  = "interactive"
-	flagRecover      = "recover"
-	flagNoBackup     = "no-backup"
-	flagCoinType     = "coin-type"
-	flagAccount      = "account"
-	flagIndex        = "index"
-	flagMultisig     = "multisig"
-	flagNoSort       = "nosort"
-	flagHDPath       = "hd-path"
-	flagLegacyHdPath = "legacy-hd-path"
+	flagInteractive     = "interactive"
+	flagRecover         = "recover"
+	flagNoBackup        = "no-backup"
+	flagCoinType        = "coin-type"
+	flagAccount         = "account"
+	flagIndex           = "index"
+	flagMultisig        = "multisig"
+	flagNoSort          = "nosort"
+	flagHDPath          = "hd-path"
+	flagCosmosLedgerApp = "cosmos-ledger-app"
 
 	// DefaultKeyPass contains the default key password for genesis transactions
 	DefaultKeyPass = "12345678"
@@ -73,7 +73,7 @@ Example:
 	f.String(FlagPublicKey, "", "Parse a public key in JSON format and saves key info to <name> file.")
 	f.BoolP(flagInteractive, "i", false, "Interactively prompt user for BIP39 passphrase and mnemonic")
 	f.Bool(flags.FlagUseLedger, false, "Store a local reference to a private key on a Ledger device")
-	f.Bool(flagLegacyHdPath, false, "Flag to specify the command uses old HD path - use this for ledger compatibility")
+	f.Bool(flagCosmosLedgerApp, false, "If using Ledger, use the old HD path, which is compatible with Cosmos app")
 	f.Bool(flagRecover, false, "Provide seed phrase to recover existing key instead of creating")
 	f.Bool(flagNoBackup, false, "Don't print out seed phrase (if others are watching the terminal)")
 	f.Bool(flags.FlagDryRun, false, "Perform action, but don't add key to local keystore")
@@ -208,9 +208,9 @@ func runAddCmd(ctx client.Context, cmd *cobra.Command, args []string, inBuf *buf
 
 	// If we're using ledger, only thing we need is the path and the bech32 prefix.
 	if useLedger {
-		legacyHdPath, _ := cmd.Flags().GetBool(flagLegacyHdPath)
-		if legacyHdPath {
-			coinType = sdk.CoinType
+		isCosmosLedgerApp, _ := cmd.Flags().GetBool(flagCosmosLedgerApp)
+		if isCosmosLedgerApp {
+			coinType = sdk.CoinType // secret's hd path used on the old cosmos app is the same one as cosmos'
 		} else {
 			coinType = DefaultLedgerCoinType
 		}

--- a/crypto/ledger/ledger_secp256k1.go
+++ b/crypto/ledger/ledger_secp256k1.go
@@ -279,7 +279,7 @@ func getPubKeyUnsafe(device SECP256K1, path hd.BIP44Params) (types.PubKey, error
 func getPubKeyAddrSafe(device SECP256K1, path hd.BIP44Params, hrp string) (types.PubKey, string, error) {
 	publicKey, addr, err := device.GetAddressPubKeySECP256K1(path.DerivationPath(), hrp)
 	if err != nil {
-		return nil, "", fmt.Errorf("%w: address rejected for path %s", err, path.String())
+		return nil, "", fmt.Errorf("%w: address rejected for path %s. Use --cosmos-ledger-app if you're using the old ledger app.", err, path.String())
 	}
 
 	// re-serialize in the 33-byte compressed format


### PR DESCRIPTION
Renamed the `--legacy-hd-path` flag to `--cosmos-ledger-app`, to better reflect its use. Tweaked help message.
I'm not 100% that this was the intention of the Monday task, which states the following:
`For v1.10: Remove --legacy-hd-path` <- This I renamed to --cosmos-ledger-app as Itzik suggested, for those users who are still using the old cosmos ledger app.
 `& fix --coin-type not showing in --help (copy)` <- This flag does show up in my experiments, though...